### PR TITLE
fix close window notif and unused vars

### DIFF
--- a/src/macosx/MacMiniFB.m
+++ b/src/macosx/MacMiniFB.m
@@ -2,14 +2,14 @@
 #include "OSXWindow.h"
 #include <Cocoa/Cocoa.h>
 #include <unistd.h>
-#include <MiniFB.h>
+#include "MiniFB.h"
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void* g_updateBuffer = 0;
 int g_width = 0;
 int g_height = 0;
-static NSWindow* window_;
+static OSXWindow* window_;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -82,6 +82,9 @@ static int updateEvents()
 		}
 	}
 	[pool release];
+
+	if (window_->closed)
+		state = -1;
 
 	return state;
 }

--- a/src/macosx/OSXWindow.h
+++ b/src/macosx/OSXWindow.h
@@ -5,6 +5,7 @@
 @interface OSXWindow : NSWindow
 {
 	NSView* childContentView;
+	@public bool closed;
 }
 
 @end

--- a/src/macosx/OSXWindow.m
+++ b/src/macosx/OSXWindow.m
@@ -6,7 +6,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (id)initWithContentRect:(NSRect)contentRect
-	styleMask:(NSUInteger)windowStyle
+	styleMask:(NSWindowStyleMask)windowStyle
 	backing:(NSBackingStoreType)bufferingType
 	defer:(BOOL)deferCreation
 {
@@ -31,6 +31,14 @@
 			selector:@selector(mainWindowChanged:)
 			name:NSWindowDidResignMainNotification
 			object:self];
+
+		[[NSNotificationCenter defaultCenter]
+			addObserver:self
+			selector:@selector(willClose)
+			name:NSWindowWillCloseNotification
+			object:self];
+
+		closed = false;
 	}
 	return self;
 }
@@ -65,6 +73,7 @@
 
 - (void)mainWindowChanged:(NSNotification *)aNotification
 {
+	(void)aNotification;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -128,9 +137,17 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-+ (NSRect)frameRectForContentRect:(NSRect)windowContentRect styleMask:(NSUInteger)windowStyle
++ (NSRect)frameRectForContentRect:(NSRect)windowContentRect styleMask:(NSWindowStyleMask)windowStyle
 {
+	(void)windowStyle;
 	return NSInsetRect(windowContentRect, 0, 0);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+- (void)willClose
+{
+	closed = true;
 }
 
 @end

--- a/src/macosx/OSXWindowFrameView.m
+++ b/src/macosx/OSXWindowFrameView.m
@@ -27,6 +27,8 @@ extern int g_height;
 
 - (void)drawRect:(NSRect)rect
 {
+	(void)rect;
+
 	if (!g_updateBuffer)
 		return;
 


### PR DESCRIPTION
It wasn't detecting that the window was closed when I closed it by
clicking the red X button. As a result, the window would close, but
mfb_update() didn't return -1, so the program kept running.

This was fixed by listening to the willClose event and using it to set a
flag. I'm not sure if this is the best way to do it, I really know
nothing about OSX/Cocoa.

Also, I fixed a few unused varible warnings. And warnings related to
NSUInteger not matching the expected signature with NSWindowStyleMask.

Also, I switched <MiniFB.h> with "MiniFB.h", since it had the same problem as on Windows with VC++.