### PR TITLE
Got this working on 10.11

### DIFF
--- a/src/macosx/OSXWindow.m
+++ b/src/macosx/OSXWindow.m
@@ -6,7 +6,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (id)initWithContentRect:(NSRect)contentRect
-	styleMask:(NSWindowStyleMask)windowStyle
+	styleMask:(NSUInteger)windowStyle
 	backing:(NSBackingStoreType)bufferingType
 	defer:(BOOL)deferCreation
 {
@@ -137,7 +137,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-+ (NSRect)frameRectForContentRect:(NSRect)windowContentRect styleMask:(NSWindowStyleMask)windowStyle
++ (NSRect)frameRectForContentRect:(NSRect)windowContentRect styleMask:(NSUInteger)windowStyle
 {
 	(void)windowStyle;
 	return NSInsetRect(windowContentRect, 0, 0);


### PR DESCRIPTION
Prefacing this with the note that I don't know a lick of Objective-C, so there's probably a more type-safe way to do this. I was getting these mismatched-parameter-type errors:

```
⚡  tundra2 macosx-clang-debug
ObjC src/macosx/OSXWindow.m
/Users/ankeet.presswala/code/lib/minifb/src/macosx/OSXWindow.m:9:13: error: expected a type
        styleMask:(NSWindowStyleMask)windowStyle
                   ^
/Users/ankeet.presswala/code/lib/minifb/src/macosx/OSXWindow.m:140:72: error: expected a type
+ (NSRect)frameRectForContentRect:(NSRect)windowContentRect styleMask:(NSWindowStyleMask)windowStyle
                                                                       ^
/Users/ankeet.presswala/code/lib/minifb/src/macosx/OSXWindow.m:15:13: error: incompatible pointer to integer conversion sending 'id' to parameter of type 'NSUInteger' (aka 'unsigned long') [-Werror,-Wint-conversion]
                styleMask:windowStyle
                          ^~~~~~~~~~~
/System/Library/Frameworks/AppKit.framework/Headers/NSWindow.h:279:79: note: passing argument to parameter 'aStyle' here
- (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)aStyle backing:(NSBackingStoreType)bufferingType defer:(BOOL)flag;
                                                                              ^
/Users/ankeet.presswala/code/lib/minifb/src/macosx/OSXWindow.m:9:31: error: conflicting parameter types in implementation of 'initWithContentRect:styleMask:backing:defer:': 'NSUInteger' (aka 'unsigned long') vs 'id' [-Werror,-Wmismatched-parameter-types]
        styleMask:(NSWindowStyleMask)windowStyle
                                     ^
/System/Library/Frameworks/AppKit.framework/Headers/NSWindow.h:279:79: note: previous definition is here
- (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)aStyle backing:(NSBackingStoreType)bufferingType defer:(BOOL)flag;
                                                                   ~~~~~~~~~~ ^
/Users/ankeet.presswala/code/lib/minifb/src/macosx/OSXWindow.m:140:90: error: conflicting parameter types in implementation of 'frameRectForContentRect:styleMask:': 'NSUInteger' (aka 'unsigned long') vs 'id' [-Werror,-Wmismatched-parameter-types]
+ (NSRect)frameRectForContentRect:(NSRect)windowContentRect styleMask:(NSWindowStyleMask)windowStyle
                                                                                         ^
/System/Library/Frameworks/AppKit.framework/Headers/NSWindow.h:271:71: note: previous definition is here
+ (NSRect)frameRectForContentRect:(NSRect)cRect styleMask:(NSUInteger)aStyle;
                                                           ~~~~~~~~~~ ^
5 errors generated.
*** Build failed (0.47 seconds)
```

To fix this, I changed the NSWindowStyleMask parameter to an NSUInteger; this got everything building properly.