### PR TITLE
Fix size of window on MacOS.

### DIFF
--- a/src/macosx/MacMiniFB.m
+++ b/src/macosx/MacMiniFB.m
@@ -26,7 +26,8 @@ int mfb_open(const char* name, int width, int height)
 	NSWindowStyleMask styles = NSWindowStyleMaskResizable | NSWindowStyleMaskClosable | NSWindowStyleMaskTitled;
 
 	NSRect rectangle = NSMakeRect(0, 0, width, height);
-	window_ = [[OSXWindow alloc] initWithContentRect:rectangle styleMask:styles backing:NSBackingStoreBuffered defer:NO];
+	NSRect frameRect = [NSWindow frameRectForContentRect:rectangle styleMask:styles];
+	window_ = [[OSXWindow alloc] initWithContentRect:frameRect styleMask:styles backing:NSBackingStoreBuffered defer:NO];
 
 	if (!window_)
 		return 0;


### PR DESCRIPTION
The API for NSWindow's creation has a contentRect parameter,
but it seems to be handled like a frameRect. So convert from
contentRect to frameRect first. Without this change the
top 20-ish lines of the image are under the title bar.