### PR TITLE
Fixed USE_OPENGL=OFF on Windows build

### DIFF
--- a/src/windows/WinMiniFB.c
+++ b/src/windows/WinMiniFB.c
@@ -872,9 +872,6 @@ mfb_set_viewport(struct mfb_window *window, unsigned offset_x, unsigned offset_y
     calc_dst_factor(window_data, window_data->window_width, window_data->window_height);
 
 #if !defined(USE_OPENGL_API)
-    SWindowData_Win *window_data_win = 0x0;
-
-    window_data_win = (SWindowData_Win *) window_data->specific;
     BitBlt(window_data_win->hdc, 0, 0, window_data->window_width, window_data->window_height, 0, 0, 0, BLACKNESS);
 #endif
 


### PR DESCRIPTION
When building minifb on Windows without OpenGL, I get a compilation error about redefining window_data_win.
It looks like window_data_win is defined at the top of mfb_set_viewport in WinMiniFB.c, and then also within the "#if !defined(USE_OPENGL_API)" block.
This causes a redefinition when USE_OPENGL_API is not defined.

This PR simply removes the definition, and lets the library and examples all build and run.


For reference the build I used was:
cmake -DUSE_OPENGL_API=OFF -G "Unix Makefiles"