### PR TITLE
X11 support for mfb_set_char_input_callback

### DIFF
--- a/src/x11/X11MiniFB.c
+++ b/src/x11/X11MiniFB.c
@@ -236,6 +236,15 @@ processEvent(SWindowData *window_data, XEvent *event) {
 
             window_data->key_status[key_code] = is_pressed;
             kCall(keyboard_func, key_code, (mfb_key_mod) window_data->mod_keys, is_pressed);
+
+            if (event->type == KeyRelease) {
+                char c;
+                KeySym ks;
+                XComposeStatus s;
+                if (XLookupString(event, &c, 1, &ks, &s) > 0) {
+                    kCall(char_input_func, c);
+                }
+            }
         }
         break;
 

--- a/src/x11/X11MiniFB.c
+++ b/src/x11/X11MiniFB.c
@@ -241,7 +241,7 @@ processEvent(SWindowData *window_data, XEvent *event) {
                 char c;
                 KeySym ks;
                 XComposeStatus s;
-                if (XLookupString(event, &c, 1, &ks, &s) > 0) {
+                if (XLookupString(&event->xkey, &c, 1, &ks, &s) > 0) {
                     kCall(char_input_func, c);
                 }
             }


### PR DESCRIPTION
Char input events weren't being generated under X11. This extracts the character code from the event and calls calls the callback specified by mfb_set_char_input_callback(...)