### PR TITLE
macsox support for mfb_set_char_input_callback

### DIFF
--- a/src/macosx/OSXWindow.m
+++ b/src/macosx/OSXWindow.m
@@ -153,6 +153,13 @@
         short int key_code = g_keycodes[[event keyCode] & 0x1ff];
         window_data->key_status[key_code] = false;
         kCall(keyboard_func, key_code, window_data->mod_keys, false);
+
+        if (event.characters.length > 0) {
+            unichar c = [event.characters characterAtIndex:0];
+            if (c >=32 && c < 127) {
+                kCall(char_input_func, c);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Char input events weren't being generated under macos. This extracts the character code (filter out space and visible characters only) from the event and calls the callback specified by mfb_set_char_input_callback(...)