### PR TITLE
Close window confirmation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ void resize(struct mfb_window *window, int width, int height) {
     mfb_set_viewport(window, x, y, width, height);
 }
 
+void close(struct mfb_window *window) {
+    ...
+    return true;    // true => confirm close
+                    // false => don't close 
+}
+
 void keyboard(struct mfb_window *window, mfb_key key, mfb_key_mod mod, bool isPressed) {
     ...
     // Remember to close the window in some way
@@ -86,6 +92,7 @@ if (!window)
 
 mfb_set_active_callback(window, active);
 mfb_set_resize_callback(window, resize);
+mfb_set_close_callback(window, close);
 mfb_set_keyboard_callback(window, keyboard);
 mfb_set_char_input_callback(window, char_input);
 mfb_set_mouse_button_callback(window, mouse_btn);
@@ -242,6 +249,7 @@ bool                mfb_set_viewport(struct mfb_window *window, unsigned offset_
 void                mfb_set_mouse_button_callback(struct mfb_window *window, mfb_mouse_button_func callback);
 void                mfb_set_mouse_move_callback(struct mfb_window *window, mfb_mouse_move_func callback);
 void                mfb_set_resize_callback(struct mfb_window *window, mfb_resize_func callback);
+void                mfb_set_close_callback(struct mfb_window *window, mfb_close_func callback);
 
 unsigned            mfb_get_window_width(struct mfb_window *window);
 unsigned            mfb_get_window_height(struct mfb_window *window);
@@ -343,6 +351,7 @@ void                mfb_set_active_callback(struct mfb_window *window, mfb_activ
 void                mfb_set_mouse_button_callback(struct mfb_window *window, mfb_mouse_button_func callback);
 void                mfb_set_mouse_move_callback(struct mfb_window *window, mfb_mouse_move_func callback);
 void                mfb_set_resize_callback(struct mfb_window *window, mfb_resize_func callback);
+void                mfb_set_close_callback(struct mfb_window *window, mfb_close_func callback);
 
 bool                mfb_is_window_active(struct mfb_window *window);
 unsigned            mfb_get_window_width(struct mfb_window *window);

--- a/include/MiniFB.h
+++ b/include/MiniFB.h
@@ -47,6 +47,7 @@ void                mfb_get_monitor_scale(struct mfb_window *window, float *scal
 // Callbacks
 void                mfb_set_active_callback(struct mfb_window *window, mfb_active_func callback);
 void                mfb_set_resize_callback(struct mfb_window *window, mfb_resize_func callback);
+void                mfb_set_close_callback(struct mfb_window* window, mfb_close_func callback);
 void                mfb_set_keyboard_callback(struct mfb_window *window, mfb_keyboard_func callback);
 void                mfb_set_char_input_callback(struct mfb_window *window, mfb_char_input_func callback);
 void                mfb_set_mouse_button_callback(struct mfb_window *window, mfb_mouse_button_func callback);

--- a/include/MiniFB_cpp.h
+++ b/include/MiniFB_cpp.h
@@ -37,6 +37,8 @@ class mfb_stub {
     template <class T>
     friend void mfb_set_resize_callback(struct mfb_window *window, T *obj, void (T::*method)(struct mfb_window *, int, int));
     template <class T>
+    friend void mfb_set_close_callback(struct mfb_window *window, T *obj, bool (T::*method)(struct mfb_window *));
+    template <class T>
     friend void mfb_set_mouse_button_callback(struct mfb_window *window, T *obj, void (T::*method)(struct mfb_window *, mfb_mouse_button, mfb_key_mod, bool));
     template <class T>
     friend void mfb_set_keyboard_callback(struct mfb_window *window, T *obj, void (T::*method)(struct mfb_window *, mfb_key, mfb_key_mod, bool));
@@ -53,6 +55,7 @@ class mfb_stub {
 
     static void active_stub(struct mfb_window *window, bool isActive);
     static void resize_stub(struct mfb_window *window, int width, int height);
+    static bool close_stub(struct mfb_window *window);
     static void keyboard_stub(struct mfb_window *window, mfb_key key, mfb_key_mod mod, bool isPressed);
     static void char_input_stub(struct mfb_window *window, unsigned int);
     static void mouse_btn_stub(struct mfb_window *window, mfb_mouse_button button, mfb_key_mod mod, bool isPressed);
@@ -62,11 +65,12 @@ class mfb_stub {
     struct mfb_window                                                           *m_window;
     std::function<void(struct mfb_window *window, bool)>                        m_active;
     std::function<void(struct mfb_window *window, int, int)>                    m_resize;
-    std::function<void(struct mfb_window *window, mfb_key, mfb_key_mod, bool)>           m_keyboard;
+    std::function<bool(struct mfb_window *window)>                              m_close;
+    std::function<void(struct mfb_window *window, mfb_key, mfb_key_mod, bool)>  m_keyboard;
     std::function<void(struct mfb_window *window, unsigned int)>                m_char_input;
     std::function<void(struct mfb_window *window, mfb_mouse_button, mfb_key_mod, bool)>   m_mouse_btn;
     std::function<void(struct mfb_window *window, int, int)>                    m_mouse_move;
-    std::function<void(struct mfb_window *window, mfb_key_mod, float, float)>        m_scroll;
+    std::function<void(struct mfb_window *window, mfb_key_mod, float, float)>   m_scroll;
 };
 
 //-------------------------------------
@@ -86,6 +90,15 @@ inline void mfb_set_resize_callback(struct mfb_window *window, T *obj, void (T::
     mfb_stub    *stub = mfb_stub::GetInstance(window);
     stub->m_resize = std::bind(method, obj, _1, _2, _3);
     mfb_set_resize_callback(window, mfb_stub::resize_stub);
+}
+
+template <class T>
+inline void mfb_set_close_callback(struct mfb_window *window, T *obj, bool (T::*method)(struct mfb_window *window)) {
+    using namespace std::placeholders;
+
+    mfb_stub    *stub = mfb_stub::GetInstance(window);
+    stub->m_close = std::bind(method, obj, _1);
+    mfb_set_close_callback(window, mfb_stub::close_stub);
 }
 
 template <class T>

--- a/include/MiniFB_enums.h
+++ b/include/MiniFB_enums.h
@@ -177,6 +177,7 @@ struct mfb_timer;
 // Event callbacks
 typedef void(*mfb_active_func)(struct mfb_window *window, bool isActive);
 typedef void(*mfb_resize_func)(struct mfb_window *window, int width, int height);
+typedef bool(*mfb_close_func)(struct mfb_window* window);
 typedef void(*mfb_keyboard_func)(struct mfb_window *window, mfb_key key, mfb_key_mod mod, bool isPressed);
 typedef void(*mfb_char_input_func)(struct mfb_window *window, unsigned int code);
 typedef void(*mfb_mouse_button_func)(struct mfb_window *window, mfb_mouse_button button, mfb_key_mod mod, bool isPressed);

--- a/src/MiniFB_common.c
+++ b/src/MiniFB_common.c
@@ -44,6 +44,15 @@ mfb_set_resize_callback(struct mfb_window *window, mfb_resize_func callback) {
 
 //-------------------------------------
 void
+mfb_set_close_callback(struct mfb_window* window, mfb_close_func callback) {
+    if (window != 0x0) {
+        SWindowData* window_data = (SWindowData*)window;
+        window_data->close_func = callback;
+    }
+}
+
+//-------------------------------------
+void
 mfb_set_keyboard_callback(struct mfb_window *window, mfb_keyboard_func callback) {
     if(window != 0x0) {
         SWindowData *window_data = (SWindowData *) window;

--- a/src/MiniFB_common.c
+++ b/src/MiniFB_common.c
@@ -139,7 +139,9 @@ keyboard_default(struct mfb_window *window, mfb_key key, mfb_key_mod mod, bool i
     kUnused(isPressed);
     if (key == KB_KEY_ESCAPE) {
         SWindowData *window_data = (SWindowData *) window;
-        window_data->close = true;
+        if (!window_data->close_func || window_data->close_func((struct mfb_window*)window_data)) {
+            window_data->close = true;
+        }
     }
 }
 

--- a/src/MiniFB_cpp.cpp
+++ b/src/MiniFB_cpp.cpp
@@ -34,6 +34,13 @@ mfb_stub::resize_stub(struct mfb_window *window, int width, int height) {
 }
 
 //-------------------------------------
+bool 
+mfb_stub::close_stub(struct mfb_window *window) {
+    mfb_stub    *stub = mfb_stub::GetInstance(window);
+    return stub->m_close(window);
+}
+
+//-------------------------------------
 void 
 mfb_stub::keyboard_stub(struct mfb_window *window, mfb_key key, mfb_key_mod mod, bool isPressed) {
     mfb_stub    *stub = mfb_stub::GetInstance(window);

--- a/src/WindowData.h
+++ b/src/WindowData.h
@@ -11,7 +11,8 @@ typedef struct {
 
     mfb_active_func         active_func;
     mfb_resize_func         resize_func;
-    mfb_keyboard_func       keyboard_func;
+    mfb_close_func          close_func;
+	mfb_keyboard_func       keyboard_func;
     mfb_char_input_func     char_input_func;
     mfb_mouse_button_func   mouse_btn_func;
     mfb_mouse_move_func     mouse_move_func;

--- a/src/macosx/OSXWindow.m
+++ b/src/macosx/OSXWindow.m
@@ -237,6 +237,21 @@
     }
 }
 
+- (BOOL)windowShouldClose:(NSWindow *) window 
+{
+    bool destroy = false;
+    if (!window_data) {
+        destroy = true;
+    } else {
+        // Obtain a confirmation of close
+        if (!window_data->close_func || window_data->close_func((struct mfb_window*)window_data)) {
+            destroy = true;
+        }
+    }
+
+    return destroy;
+}
+
 - (void)windowWillClose:(NSNotification *)notification {
     kUnused(notification);
     if(window_data) {

--- a/src/macosx/OSXWindow.m
+++ b/src/macosx/OSXWindow.m
@@ -153,6 +153,11 @@
         short int key_code = g_keycodes[[event keyCode] & 0x1ff];
         window_data->key_status[key_code] = false;
         kCall(keyboard_func, key_code, window_data->mod_keys, false);
+        
+        if (event.characters.length > 0) {
+            unichar c = [event.characters characterAtIndex:0];
+            kCall(char_input_func, c);
+        }
     }
 }
 

--- a/src/windows/WinMiniFB.c
+++ b/src/windows/WinMiniFB.c
@@ -223,12 +223,22 @@ WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
             break;
         }
 #endif
-
-        case WM_DESTROY:
         case WM_CLOSE:
         {
             if (window_data) {
-                window_data->close = true;
+                bool destroy = false;
+
+                // Obtain a confirmation of close
+                if (!window_data->close_func || window_data->close_func((struct mfb_window*)window_data)) {
+                    destroy = true;
+                }
+
+                if (destroy) {
+                    window_data->close = true;
+                    if (window_data_win) {
+                        DestroyWindow(window_data_win->window);
+                    }
+                }
             }
             break;
         }

--- a/src/windows/WinMiniFB.c
+++ b/src/windows/WinMiniFB.c
@@ -243,6 +243,12 @@ WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
             break;
         }
 
+        case WM_DESTROY:
+            if (window_data) {
+                window_data->close = true;
+            }
+            break;
+
         case WM_KEYDOWN:
         case WM_SYSKEYDOWN:
         case WM_KEYUP:

--- a/src/x11/X11MiniFB.c
+++ b/src/x11/X11MiniFB.c
@@ -365,8 +365,19 @@ processEvent(SWindowData *window_data, XEvent *event) {
         case ClientMessage:
         {
             if ((Atom)event->xclient.data.l[0] == s_delete_window_atom) {
-                window_data->close = true;
-                return;
+                if (window_data) {
+                    bool destroy = false;
+
+                    // Obtain a confirmation of close
+                    if (!window_data->close_func || window_data->close_func((struct mfb_window*)window_data)) {
+                        destroy = true;
+                    }
+
+                    if (destroy) {
+                        window_data->close = true;
+                        return;
+                    }
+                }
             }
         }
         break;

--- a/tests/input_events.c
+++ b/tests/input_events.c
@@ -11,7 +11,7 @@ static bool         g_active = true;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void
+static void
 active(struct mfb_window *window, bool isActive) {
     const char *window_title = "";
     if(window) {
@@ -21,7 +21,7 @@ active(struct mfb_window *window, bool isActive) {
     g_active = isActive;
 }
 
-void
+static void
 resize(struct mfb_window *window, int width, int height) {
     uint32_t x = 0;
     uint32_t y = 0;
@@ -42,17 +42,17 @@ resize(struct mfb_window *window, int width, int height) {
     mfb_set_viewport(window, x, y, width, height);
 }
 
-bool
+static bool
 close(struct mfb_window *window) {
     const char* window_title = "";
     if (window) {
         window_title = (const char*)mfb_get_user_data(window);
     }
 	fprintf(stdout, "%s > close\n", window_title);
-    return true; // Yes, confirm close
+    return true; // true => confirm close
 }
 
-void
+static void
 keyboard(struct mfb_window *window, mfb_key key, mfb_key_mod mod, bool isPressed) {
     const char *window_title = "";
     if(window) {
@@ -64,7 +64,7 @@ keyboard(struct mfb_window *window, mfb_key key, mfb_key_mod mod, bool isPressed
     }
 }
 
-void
+static void
 char_input(struct mfb_window *window, unsigned int charCode) {
     const char *window_title = "";
     if(window) {
@@ -73,7 +73,7 @@ char_input(struct mfb_window *window, unsigned int charCode) {
     fprintf(stdout, "%s > charCode: %d\n", window_title, charCode);
 }
 
-void
+static void
 mouse_btn(struct mfb_window *window, mfb_mouse_button button, mfb_key_mod mod, bool isPressed) {
     const char *window_title = "";
     int x, y;
@@ -85,19 +85,19 @@ mouse_btn(struct mfb_window *window, mfb_mouse_button button, mfb_key_mod mod, b
     fprintf(stdout, "%s > mouse_btn: button: %d (pressed: %d) (at: %d, %d) [key_mod: %x]\n", window_title, button, isPressed, x, y, mod);
 }
 
-void
+static void
 mouse_move(struct mfb_window *window, int x, int y) {
     kUnused(window);
     kUnused(x);
     kUnused(y);
-    // const char *window_title = "";
-    // if(window) {
-    //     window_t(const char *) itle = mfb_get_user_data(window);
-    // }
-    //fprintf(stdout, "%s > mouse_move: %d, %d\n", window_title, x, y);
+    const char *window_title = "";
+    if(window) {
+        window_title = mfb_get_user_data(window);
+    }
+    fprintf(stdout, "%s > mouse_move: %d, %d\n", window_title, x, y);
 }
 
-void
+static void
 mouse_scroll(struct mfb_window *window, mfb_key_mod mod, float deltaX, float deltaY) {
     const char *window_title = "";
     if(window) {

--- a/tests/input_events.c
+++ b/tests/input_events.c
@@ -42,6 +42,16 @@ resize(struct mfb_window *window, int width, int height) {
     mfb_set_viewport(window, x, y, width, height);
 }
 
+bool
+close(struct mfb_window *window) {
+    const char* window_title = "";
+    if (window) {
+        window_title = (const char*)mfb_get_user_data(window);
+    }
+	fprintf(stdout, "%s > close\n", window_title);
+    return true; // Yes, confirm close
+}
+
 void
 keyboard(struct mfb_window *window, mfb_key key, mfb_key_mod mod, bool isPressed) {
     const char *window_title = "";
@@ -109,6 +119,7 @@ main()
 
     mfb_set_active_callback(window, active);
     mfb_set_resize_callback(window, resize);
+    mfb_set_close_callback(window, close);
     mfb_set_keyboard_callback(window, keyboard);
     mfb_set_char_input_callback(window, char_input);
     mfb_set_mouse_button_callback(window, mouse_btn);

--- a/tests/input_events.c
+++ b/tests/input_events.c
@@ -49,7 +49,8 @@ close(struct mfb_window *window) {
         window_title = (const char*)mfb_get_user_data(window);
     }
 	fprintf(stdout, "%s > close\n", window_title);
-    return true; // true => confirm close
+    return true;    // true => confirm close
+                    // false => don't close 
 }
 
 static void

--- a/tests/input_events_cpp.cpp
+++ b/tests/input_events_cpp.cpp
@@ -40,6 +40,16 @@ public:
         mfb_set_viewport(window, x, y, width, height);
     }
 
+    bool close(struct mfb_window *window) {
+        const char* window_title = "";
+        if (window) {
+            window_title = (const char*) mfb_get_user_data(window);
+        }
+        fprintf(stdout, "%s > close\n", window_titl0e);
+        return true;    // true => confirm close
+                        // false => don't close 
+    }
+
     void keyboard(struct mfb_window *window, mfb_key key, mfb_key_mod mod, bool isPressed) {
         const char *window_title = "";
         if(window) {
@@ -106,6 +116,7 @@ main()
 
     mfb_set_active_callback(window, &e, &Events::active);
     mfb_set_resize_callback(window, &e, &Events::resize);
+    mfb_set_close_callback(window, &e, &Events::close);
     mfb_set_keyboard_callback(window, &e, &Events::keyboard);
     mfb_set_char_input_callback(window, &e, &Events::char_input);
     mfb_set_mouse_button_callback(window, &e, &Events::mouse_btn);


### PR DESCRIPTION
This feature supports the following story:

_As a user, I want confirmation of any unsaved changes when I close the application's window._

This provides close window confirmation support for Windows, X11 and Macos. The close handler can return true for confirm window closure or false to prevent closure using mfb_set_close_callback(...)

If no callback is specified (default), then the window will close as usual.

Note: support not required for mobiles.
