### PR TITLE
Fix: remove duplicate char press on MacOS

### DIFF
--- a/src/macosx/OSXWindow.m
+++ b/src/macosx/OSXWindow.m
@@ -154,11 +154,6 @@
         short int key_code = g_keycodes[[event keyCode] & 0x1ff];
         window_data->key_status[key_code] = false;
         kCall(keyboard_func, key_code, window_data->mod_keys, false);
-        
-        if (event.characters.length > 0) {
-            unichar c = [event.characters characterAtIndex:0];
-            kCall(char_input_func, c);
-        }
     }
 }
 


### PR DESCRIPTION
Now getting duplicate key presses on MacOS. This part of the code isn't required anymore since improvements by @Darky-Lucera to insertText. Not sure why this has come back in (probably due to later merge issues)