### PR TITLE
Optimize cmake message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.7)
 set(PROJECT_NAME MiniFB)
 project(${PROJECT_NAME})
 
-message("Processing " ${PROJECT_NAME})
+message(STATUS "Processing " ${PROJECT_NAME})
 
 # Detect iOS
 #--------------------------------------
@@ -339,4 +339,4 @@ if(MINIFB_BUILD_EXAMPLES)
 
 endif()
 
-message("Done " ${PROJECT_NAME})
+message(STATUS "Done " ${PROJECT_NAME})


### PR DESCRIPTION
Before: 
```
-- The C compiler identification is AppleClang 12.0.0.12000032
-- The CXX compiler identification is AppleClang 12.0.0.12000032
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
Processing MiniFB
Done MiniFB
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/xiaozhuai/work/soft_renderer/cmake-build-debug
```

After:
```
-- The C compiler identification is AppleClang 12.0.0.12000032
-- The CXX compiler identification is AppleClang 12.0.0.12000032
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Processing MiniFB
-- Done MiniFB
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/xiaozhuai/work/soft_renderer/cmake-build-debug
```