### PR TITLE
For X11, turn off key auto repeats

### DIFF
--- a/src/x11/X11MiniFB.c
+++ b/src/x11/X11MiniFB.c
@@ -65,6 +65,7 @@ mfb_open_ex(const char *title, unsigned width, unsigned height, unsigned flags) 
     }
 
     init_keycodes(window_data_x11);
+    XAutoRepeatOff(window_data_x11->display);
 
     window_data_x11->screen = DefaultScreen(window_data_x11->display);
 


### PR DESCRIPTION
On macos (Majave+) and Windows, an extended keypress down does not result in multiple key-up/key-down events (i.e. key repeating).  This change brings the x11 behavior to OS parity by disabling key repeating events for X11.  Verified patched behavior is consistent among Ubuntu LTS 20.20 at terminal, via "ssh -Y", and via WSL on Windows 10 (with and without USE_OPENGL_API).