### PR TITLE
Rework X11 auto repeat commit b8369b2, PR#89

### DIFF
--- a/src/x11/X11MiniFB.c
+++ b/src/x11/X11MiniFB.c
@@ -65,7 +65,6 @@ mfb_open_ex(const char *title, unsigned width, unsigned height, unsigned flags) 
     }
 
     init_keycodes(window_data_x11);
-    XAutoRepeatOff(window_data_x11->display);
 
     window_data_x11->screen = DefaultScreen(window_data_x11->display);
 
@@ -232,6 +231,19 @@ processEvent(SWindowData *window_data, XEvent *event) {
         case KeyPress:
         case KeyRelease:
         {
+            SWindowData_X11 *window_data_x11 = (SWindowData_X11 *) window_data->specific;
+            if ((event->type == KeyRelease) &&
+                XEventsQueued(window_data_x11->display, QueuedAfterReading)) {
+                XEvent nev;
+                XPeekEvent(window_data_x11->display, &nev);
+
+                if ((nev.type == KeyPress) && (nev.xkey.time == event->xkey.time) &&
+                    (nev.xkey.keycode == event->xkey.keycode)) {
+                    /* Key wasn’t actually released */
+                    return;
+                }
+            }
+
             mfb_key key_code      = (mfb_key) translate_key(event->xkey.keycode);
             int is_pressed        = (event->type == KeyPress);
             window_data->mod_keys = translate_mod_ex(key_code, event->xkey.state, is_pressed);


### PR DESCRIPTION
The earlier change modified the system global X11 key repeat behavior by
disabling KeyRepeat events.  This change is a rework to filter a
KeyRelease-KeyPress sequence occurring within the same time quantum.

This change address the behavior observed by @JackClouseau while keeping key repeating party with MacOS and Windows.  For reference, holding down a key won't cause subsequent KeyRelease events.  Only KeyPress events continue to be emitted when tested with the `input_events` test application--this behavior is observed among the three tested platforms.