### PR TITLE
Fixes mouse coordinate scaling if canvas was resized

### DIFF
--- a/src/web/WebMiniFB.c
+++ b/src/web/WebMiniFB.c
@@ -280,8 +280,8 @@ EM_JS(void*, mfb_open_ex_js,(SWindowData *windowData, const char *title, unsigne
     function getMousePos(event) {
         let rect = canvas.getBoundingClientRect();
         let pos = { x: event.clientX - rect.left, y: event.clientY - rect.top };
-        pos.x = pos.x / canvas.clientWidth * canvas.width;
-        pos.y = pos.y / canvas.clientHeight * canvas.height;
+        pos.x = pos.x / canvas.clientWidth * width;
+        pos.y = pos.y / canvas.clientHeight * height;
         return pos;
     };
 


### PR DESCRIPTION
If the canvas was resized to a size != the initial window dimensions passed to minifb_open, the mouse coordinate scaling is incorrect. This fix uses the original window width/height to rescale the mouse coordinates.