### PR TITLE
[web] Fixing bad keyboard up event propagation.

### DIFF
--- a/src/web/WebMiniFB.c
+++ b/src/web/WebMiniFB.c
@@ -314,7 +314,7 @@ EM_JS(void*, mfb_open_ex_js,(SWindowData *windowData, const char *title, unsigne
         Module._window_data_set_key(windowData, code, 0);
         let mod = getMfbKeyModFromEvent(event);
         Module._window_data_set_mod_keys(windowData, mod);
-        w.events.push({ type: "keydown", code: code, mod: mod });
+        w.events.push({ type: "keyup", code: code, mod: mod });
     });
 
     canvas.addEventListener("mousedown", (event) => {


### PR DESCRIPTION
Fixing wrong keyboard event data push.

isPressed arg on keyup was true due to a wrong keydown event being push on real keyup user-input.