### PR TITLE
fixed only undefining our deprecation macro in c++

### DIFF
--- a/include/MiniFB.h
+++ b/include/MiniFB.h
@@ -142,7 +142,7 @@ double              mfb_timer_get_resolution(void);
     #include "MiniFB_cpp.h"
 #endif
 
+#endif
+
 // don't want to bleed our deprecation macro
 #undef __MFB_DEPRECATED
-
-#endif


### PR DESCRIPTION
we had `#undef __MFB_DEPRECATED` inside the `#ifdef __cplusplus` in include/MiniFB.h