### PR TITLE
Add mfb_set_title() to change window title after creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ MiniFB has been tested on Windows, macOS, Linux, iOS, Android, web, and DOSBox-x
 struct mfb_window * mfb_open(const char *title, unsigned width, unsigned height);
 struct mfb_window * mfb_open_ex(const char *title, unsigned width, unsigned height, unsigned flags);
 void                mfb_close(struct mfb_window *window);
+void                mfb_set_title(struct mfb_window *window, const char *title);
 
 // Update and synchronization
 mfb_update_state    mfb_update(struct mfb_window *window, void *buffer);

--- a/include/MiniFB.h
+++ b/include/MiniFB.h
@@ -44,6 +44,9 @@ mfb_update_state    mfb_update_events(struct mfb_window *window);
 // Close the window
 void                mfb_close(struct mfb_window *window);
 
+// Set title
+void                mfb_set_title(struct mfb_window *window, const char *title);
+
 // Set user data
 void                mfb_set_user_data(struct mfb_window *window, void *user_data);
 void *              mfb_get_user_data(struct mfb_window *window);

--- a/src/android/AndroidMiniFB.c
+++ b/src/android/AndroidMiniFB.c
@@ -946,6 +946,13 @@ mfb_set_viewport(struct mfb_window *window, unsigned offset_x, unsigned offset_y
 
 //-------------------------------------
 void
+mfb_set_title(struct mfb_window *window, const char *title) {
+    (void) window;
+    (void) title;
+}
+
+//-------------------------------------
+void
 mfb_show_cursor(struct mfb_window *window, bool show) {
     kUnused(window);
     kUnused(show);

--- a/src/ios/iOSMiniFB.m
+++ b/src/ios/iOSMiniFB.m
@@ -459,6 +459,13 @@ mfb_set_viewport(struct mfb_window *window, unsigned offset_x, unsigned offset_y
 }
 
 //-------------------------------------
+void
+mfb_set_title(struct mfb_window *window, const char *title) {
+    (void) window;
+    (void) title;
+}
+
+//-------------------------------------
 extern double   g_timer_frequency;
 extern double   g_timer_resolution;
 

--- a/src/macos/MacMiniFB.m
+++ b/src/macos/MacMiniFB.m
@@ -751,6 +751,24 @@ mfb_set_viewport(struct mfb_window *window, unsigned offset_x, unsigned offset_y
 
 //-------------------------------------
 void
+mfb_set_title(struct mfb_window *window, const char *title) {
+    if (window == 0x0 || title == 0x0) {
+        return;
+    }
+
+    SWindowData *window_data = (SWindowData *) window;
+    SWindowData_OSX *window_data_specific = (SWindowData_OSX *) window_data->specific;
+    if (window_data_specific == 0x0) {
+        return;
+    }
+
+    @autoreleasepool {
+        [window_data_specific->window setTitle:[NSString stringWithUTF8String:title]];
+    }
+}
+
+//-------------------------------------
+void
 mfb_get_monitor_scale(struct mfb_window *window, float *scale_x, float *scale_y) {
     float scale = 1.0f;
 

--- a/src/wayland/WaylandMiniFB.c
+++ b/src/wayland/WaylandMiniFB.c
@@ -2153,6 +2153,23 @@ mfb_set_viewport(struct mfb_window *window, unsigned offset_x, unsigned offset_y
 
 //-------------------------------------
 void
+mfb_set_title(struct mfb_window *window, const char *title) {
+    if (window == 0x0 || title == 0x0) {
+        return;
+    }
+
+    SWindowData *window_data = (SWindowData *) window;
+    SWindowData_Way *window_data_specific = (SWindowData_Way *) window_data->specific;
+    if (window_data_specific == 0x0) {
+        return;
+    }
+
+    xdg_toplevel_set_title(window_data_specific->toplevel, title);
+    wl_surface_commit(window_data_specific->surface);
+}
+
+//-------------------------------------
+void
 mfb_get_monitor_scale(struct mfb_window *window, float *scale_x, float *scale_y) {
     float x = 1.0f, y = 1.0f;
 

--- a/src/web/WebMiniFB.c
+++ b/src/web/WebMiniFB.c
@@ -889,6 +889,13 @@ mfb_set_viewport(struct mfb_window *window, unsigned offset_x, unsigned offset_y
 }
 
 //-------------------------------------
+void
+mfb_set_title(struct mfb_window *window, const char *title) {
+    (void) window;
+    (void) title;
+}
+
+//-------------------------------------
 EM_JS(mfb_update_state, mfb_update_events_js, (SWindowData * window_data), {
     // FIXME can we make these global somehow? --pre-js maybe?
     const MFB_STATE_OK = 0;

--- a/src/windows/WinMiniFB.c
+++ b/src/windows/WinMiniFB.c
@@ -1210,6 +1210,22 @@ mfb_set_viewport(struct mfb_window *window, unsigned offset_x, unsigned offset_y
 
 //-------------------------------------
 void
+mfb_set_title(struct mfb_window *window, const char *title) {
+    if (window == 0x0 || title == 0x0) {
+        return;
+    }
+
+    SWindowData *window_data = (SWindowData *) window;
+    SWindowData_Win *window_data_specific = (SWindowData_Win *) window_data->specific;
+    if (window_data_specific == 0x0) {
+        return;
+    }
+
+    SetWindowTextA(window_data_specific->window, title);
+}
+
+//-------------------------------------
+void
 mfb_get_monitor_scale(struct mfb_window *window, float *scale_x, float *scale_y) {
     float x = 1.0f;
     float y = 1.0f;

--- a/src/x11/X11MiniFB.c
+++ b/src/x11/X11MiniFB.c
@@ -1511,6 +1511,23 @@ mfb_set_viewport(struct mfb_window *window, unsigned offset_x, unsigned offset_y
 
 //-------------------------------------
 void
+mfb_set_title(struct mfb_window *window, const char *title) {
+    if (window == 0x0 || title == 0x0) {
+        return;
+    }
+
+    SWindowData *window_data = (SWindowData *) window;
+    SWindowData_X11 *window_data_specific = window_data->specific;
+    if (window_data_specific == 0x0) {
+        return;
+    }
+
+    XStoreName(window_data_specific->display, window_data_specific->window, title);
+    XFlush(window_data_specific->display);
+}
+
+//-------------------------------------
+void
 mfb_get_monitor_scale(struct mfb_window *window, float *scale_x, float *scale_y) {
     float x = 1.0f, y = 1.0f;
 


### PR DESCRIPTION
The Rust version of minifb supports `set_title()`, but the C version 
does not. This is useful for displaying dynamic info in the title bar 
(e.g. FPS counter).

This PR adds `mfb_set_title(struct mfb_window *window, const char *title)` 
with implementations for Windows, macOS, X11, and Wayland. 
Platforms where it doesn't apply (iOS, Android, Web, DOS) get no-op stubs.

Changes:
- include/MiniFB.h: added declaration
- src/windows/WinMiniFB.c: SetWindowTextA
- src/macosx/MacMiniFB.m: [NSWindow setTitle:]
- src/x11/X11MiniFB.c: XStoreName
- src/wayland/WaylandMiniFB.c: xdg_toplevel_set_title
- src/ios, android, web, dos: no-op stubs
- README.md: documented in API Reference