### PR TITLE
macOS fix - prevent focus-sync flagsChanged events from toggling alphanumeric keys

### DIFF
--- a/src/macos/OSXWindow.m
+++ b/src/macos/OSXWindow.m
@@ -156,7 +156,7 @@ set_frame_view_window_data(NSView *frame_view, SWindowData *window_data) {
                 is_pressed = (mod_keys & MFB_KB_MOD_SUPER) != 0;
                 break;
             default:
-                is_pressed = !window_data->key_status[key_code];
+                is_pressed = window_data->key_status[key_code];
                 break;
         }
 

--- a/src/macos/OSXWindow.m
+++ b/src/macos/OSXWindow.m
@@ -156,8 +156,8 @@ set_frame_view_window_data(NSView *frame_view, SWindowData *window_data) {
                 is_pressed = (mod_keys & MFB_KB_MOD_SUPER) != 0;
                 break;
             default:
-                is_pressed = window_data->key_status[key_code];
-                break;
+                [super flagsChanged:event];
+                return;
         }
 
         if (window_data->key_status[key_code] != is_pressed) {


### PR DESCRIPTION
#### Summary

This PR fixes a bug on macOS where refocusing the window (e.g., after a `Cmd+Tab` sequence) triggers a ghost/phantom key press—most notably on key code `0` (`A`), disrupting engine inputs and game movement.

#### Cause

On macOS, `flagsChanged:` is intended strictly for tracking system modifier keys (Shift, Ctrl, Alt, Command). However, during window focus restoration, the system can pass a dummy/zero fallback event payload into the handler.

In `OSXWindow.m`, the `default:` case within `flagsChanged:` was evaluating unknown or fallback key codes with:

```objc
is_pressed = !window_data->key_status[key_code];

```

This inverted the state of key code `0` from `false` to `true`, treating the focus synchronization artifact as a genuine physical key-down event.

#### Solution

Updated the `default:` fallback inside `flagsChanged:` to preserve the existing key status instead of blindly flipping it:

```objc
is_pressed = window_data->key_status[key_code];

```

This ensures that modifier-only flag change events never inadvertently alter the state of standard alphanumeric keys.

---

### Steps to Reproduce

1. Run a sample application using `minifb` on macOS.
2. Press and release `Cmd+Tab` to switch away from the window, between a few other apps for a few seconds, and back into the sample app.
3. Observe that key code `0` (`A` / left movement) fires a spurious down state without user interaction.
4. *With this fix applied:* Focus transitions cleanly with zero stray inputs.

### Screen Recording / Demonstration

Note here the image should move with WASD, so it does ghostly move left `A` when I `CMD+Tab` focus back to the application/game. And in this screen recording, I only press `CMD+Tab`, I never press `A` at all


https://github.com/user-attachments/assets/39ac96e3-09d1-4213-ae9e-d0eb6cd9916d

